### PR TITLE
feat: implement etcd storage for v2 storage layer

### DIFF
--- a/pkg/v2/storage/etcd/create.go
+++ b/pkg/v2/storage/etcd/create.go
@@ -1,0 +1,80 @@
+package etcd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kyverno/reports-server/pkg/v2/storage"
+	"k8s.io/klog/v2"
+)
+
+// Create inserts a new resource into etcd.
+//
+// Semantics: STRICT - Fails if resource already exists (standard Kubernetes behavior)
+//
+// The implementation first checks if the resource exists via Get(), then performs Put.
+// This ensures strict Create semantics matching Kubernetes API.
+//
+// Returns:
+//   - nil on success
+//   - storage.ErrAlreadyExists if resource already exists
+//   - Other errors for etcd/marshaling failures
+func (r *EtcdRepository[T]) Create(ctx context.Context, obj T) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := r.keyFromObject(obj)
+
+	// Check if resource already exists
+	resp, err := r.client.Get(ctx, key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to check if resource exists in etcd",
+			"type", r.resourceType,
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+		)
+		return fmt.Errorf("failed to check existence for %s: %w", r.resourceType, err)
+	}
+
+	if len(resp.Kvs) > 0 {
+		klog.V(4).InfoS("Resource already exists in etcd, cannot create",
+			"type", r.resourceType,
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+			"key", key,
+		)
+		return storage.NewAlreadyExistsError(r.resourceType, obj.GetName(), obj.GetNamespace())
+	}
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(obj)
+	if err != nil {
+		klog.ErrorS(err, "Failed to marshal resource",
+			"type", r.resourceType,
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+		)
+		return fmt.Errorf("failed to marshal %s: %w", r.resourceType, err)
+	}
+
+	// Store in etcd
+	_, err = r.client.Put(ctx, key, string(jsonData))
+	if err != nil {
+		klog.ErrorS(err, "Failed to create resource in etcd",
+			"type", r.resourceType,
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+		)
+		return fmt.Errorf("failed to create %s in etcd: %w", r.resourceType, err)
+	}
+
+	klog.V(4).InfoS("Created resource in etcd",
+		"type", r.resourceType,
+		"name", obj.GetName(),
+		"namespace", obj.GetNamespace(),
+		"key", key,
+	)
+
+	return nil
+}

--- a/pkg/v2/storage/etcd/delete.go
+++ b/pkg/v2/storage/etcd/delete.go
@@ -1,0 +1,61 @@
+package etcd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kyverno/reports-server/pkg/v2/storage"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+)
+
+// Delete removes a resource from etcd matching the filter.
+// Filter should specify Name (required) and Namespace (for namespaced resources).
+//
+// Returns:
+//   - nil on success
+//   - NotFound error if resource doesn't exist
+//   - Other errors for etcd/validation failures
+func (r *EtcdRepository[T]) Delete(ctx context.Context, filter storage.Filter) error {
+	if err := filter.ValidateForDelete(); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := r.getKey(filter.Name, filter.Namespace)
+
+	// Delete from etcd
+	resp, err := r.client.Delete(ctx, key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to delete resource from etcd",
+			"type", r.resourceType,
+			"name", filter.Name,
+			"namespace", filter.Namespace,
+			"key", key,
+		)
+		return fmt.Errorf("failed to delete %s from etcd: %w", r.resourceType, err)
+	}
+
+	// Check if resource was actually deleted
+	if resp.Deleted == 0 {
+		klog.V(4).InfoS("Resource not found in etcd, cannot delete",
+			"type", r.resourceType,
+			"name", filter.Name,
+			"namespace", filter.Namespace,
+			"key", key,
+		)
+		return errors.NewNotFound(r.gr, filter.Name)
+	}
+
+	klog.V(4).InfoS("Deleted resource from etcd",
+		"type", r.resourceType,
+		"name", filter.Name,
+		"namespace", filter.Namespace,
+		"key", key,
+		"deleted", resp.Deleted,
+	)
+
+	return nil
+}

--- a/pkg/v2/storage/etcd/repository.go
+++ b/pkg/v2/storage/etcd/repository.go
@@ -1,0 +1,102 @@
+package etcd
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/kyverno/reports-server/pkg/v2/storage"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// EtcdRepository provides CRUD operations for any Kubernetes resource type using etcd.
+// It uses Go generics to provide type-safe operations while eliminating code duplication.
+//
+// Type parameter T must implement metav1.Object interface (GetName, GetNamespace, etc.)
+//
+// Thread-safety: This repository is safe for concurrent use via sync.Mutex.
+// All operations use a simple Mutex (not RWMutex) because etcd client handles
+// concurrent operations internally and we need exclusive access for consistency checks.
+//
+// Implements: storage.IRepository[T]
+type EtcdRepository[T metav1.Object] struct {
+	// mu protects etcd operations for consistency
+	mu sync.Mutex
+
+	// client is the etcd KV client for storage operations
+	client clientv3.KV
+
+	// gvk is the GroupVersionKind for this resource type
+	gvk schema.GroupVersionKind
+
+	// gr is the GroupResource for Kubernetes API errors
+	gr schema.GroupResource
+
+	// namespaced indicates if this resource is namespace-scoped
+	namespaced bool
+
+	// resourceType is used for logging and error messages (e.g., "PolicyReport")
+	resourceType string
+}
+
+// NewEtcdRepository creates a new etcd repository instance.
+//
+// Parameters:
+//   - client: etcd KV client for storage operations
+//   - gvk: GroupVersionKind for the resource type
+//   - gr: GroupResource for Kubernetes API compatibility
+//   - resourceType: Human-readable resource type for logging/errors
+//   - namespaced: Whether the resource is namespace-scoped
+//
+// Returns:
+//   - storage.IRepository[T]: A storage-agnostic repository implementation
+//
+// Example:
+//
+//	client, _ := clientv3.New(clientv3.Config{...})
+//	repo := NewEtcdRepository[*v1alpha2.PolicyReport](
+//	    client,
+//	    schema.GroupVersionKind{Group: "wgpolicyk8s.io", Version: "v1alpha2", Kind: "PolicyReport"},
+//	    schema.GroupResource{Group: "wgpolicyk8s.io", Resource: "policyreports"},
+//	    "PolicyReport",
+//	    true,
+//	)
+func NewEtcdRepository[T metav1.Object](
+	client clientv3.KV,
+	gvk schema.GroupVersionKind,
+	gr schema.GroupResource,
+	resourceType string,
+	namespaced bool,
+) storage.IRepository[T] {
+	return &EtcdRepository[T]{
+		client:       client,
+		gvk:          gvk,
+		gr:           gr,
+		resourceType: resourceType,
+		namespaced:   namespaced,
+	}
+}
+
+// getPrefix returns the etcd key prefix for listing operations.
+// For namespaced resources with namespace: "group/version/kind/namespace/"
+// For namespaced resources without namespace: "group/version/kind/"
+// For cluster-scoped resources: "group/version/kind/"
+func (r *EtcdRepository[T]) getPrefix(namespace string) string {
+	if r.namespaced && namespace != "" {
+		return fmt.Sprintf("%s/%s/%s/%s/", r.gvk.Group, r.gvk.Version, r.gvk.Kind, namespace)
+	}
+	return fmt.Sprintf("%s/%s/%s/", r.gvk.Group, r.gvk.Version, r.gvk.Kind)
+}
+
+// getKey generates the full etcd key for a specific resource.
+// Format: "group/version/kind/namespace/name" for namespaced
+// Format: "group/version/kind/name" for cluster-scoped
+func (r *EtcdRepository[T]) getKey(name, namespace string) string {
+	return fmt.Sprintf("%s%s", r.getPrefix(namespace), name)
+}
+
+// keyFromObject generates the etcd key from a resource object.
+func (r *EtcdRepository[T]) keyFromObject(obj T) string {
+	return r.getKey(obj.GetName(), obj.GetNamespace())
+}

--- a/pkg/v2/storage/etcd/retrieve.go
+++ b/pkg/v2/storage/etcd/retrieve.go
@@ -1,0 +1,138 @@
+package etcd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kyverno/reports-server/pkg/v2/storage"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+)
+
+// Get retrieves a single resource by name and namespace from etcd.
+// For cluster-scoped resources, pass empty string for namespace.
+//
+// Returns:
+//   - The resource if found
+//   - NotFound error if resource doesn't exist
+//   - Other errors for etcd/marshaling failures
+func (r *EtcdRepository[T]) Get(ctx context.Context, filter storage.Filter) (T, error) {
+	var nilObj T
+
+	if err := filter.ValidateForGet(); err != nil {
+		return nilObj, err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := r.getKey(filter.Name, filter.Namespace)
+
+	resp, err := r.client.Get(ctx, key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get resource from etcd",
+			"type", r.resourceType,
+			"name", filter.Name,
+			"namespace", filter.Namespace,
+			"key", key,
+		)
+		return nilObj, fmt.Errorf("failed to get %s from etcd: %w", r.resourceType, err)
+	}
+
+	if len(resp.Kvs) == 0 {
+		klog.V(4).InfoS("Resource not found in etcd",
+			"type", r.resourceType,
+			"name", filter.Name,
+			"namespace", filter.Namespace,
+			"key", key,
+		)
+		return nilObj, errors.NewNotFound(r.gr, filter.Name)
+	}
+
+	if len(resp.Kvs) != 1 {
+		klog.ErrorS(nil, "Unexpected number of resources returned from etcd",
+			"type", r.resourceType,
+			"name", filter.Name,
+			"namespace", filter.Namespace,
+			"count", len(resp.Kvs),
+		)
+		return nilObj, fmt.Errorf("expected 1 resource, got %d", len(resp.Kvs))
+	}
+
+	// Unmarshal JSON to typed object
+	var obj T
+	err = json.Unmarshal(resp.Kvs[0].Value, &obj)
+	if err != nil {
+		klog.ErrorS(err, "Failed to unmarshal resource from etcd",
+			"type", r.resourceType,
+			"name", filter.Name,
+			"namespace", filter.Namespace,
+		)
+		return nilObj, fmt.Errorf("failed to unmarshal %s: %w", r.resourceType, err)
+	}
+
+	klog.V(5).InfoS("Retrieved resource from etcd",
+		"type", r.resourceType,
+		"name", filter.Name,
+		"namespace", filter.Namespace,
+	)
+
+	return obj, nil
+}
+
+// List retrieves all resources from etcd, optionally filtered by namespace.
+// For cluster-scoped resources, namespace parameter is ignored.
+// Pass empty string for namespace to get all resources across all namespaces.
+//
+// Returns:
+//   - Slice of resources (empty slice if none found)
+//   - Error for etcd/validation failures (not for empty results)
+func (r *EtcdRepository[T]) List(ctx context.Context, filter storage.Filter) ([]T, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	prefix := r.getPrefix(filter.Namespace)
+
+	resp, err := r.client.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		klog.ErrorS(err, "Failed to list resources from etcd",
+			"type", r.resourceType,
+			"namespace", filter.Namespace,
+			"prefix", prefix,
+		)
+		return nil, fmt.Errorf("failed to list %s from etcd: %w", r.resourceType, err)
+	}
+
+	if len(resp.Kvs) == 0 {
+		klog.V(4).InfoS("No resources found in etcd",
+			"type", r.resourceType,
+			"namespace", filter.Namespace,
+		)
+		return []T{}, nil
+	}
+
+	// Unmarshal all resources
+	results := make([]T, 0, len(resp.Kvs))
+	for _, kv := range resp.Kvs {
+		var obj T
+		err = json.Unmarshal(kv.Value, &obj)
+		if err != nil {
+			klog.ErrorS(err, "Failed to unmarshal resource from etcd, skipping",
+				"type", r.resourceType,
+				"key", string(kv.Key),
+			)
+			continue // Skip invalid JSON
+		}
+		results = append(results, obj)
+	}
+
+	klog.V(4).InfoS("Listed resources from etcd",
+		"type", r.resourceType,
+		"namespace", filter.Namespace,
+		"count", len(results),
+	)
+
+	return results, nil
+}

--- a/pkg/v2/storage/etcd/update.go
+++ b/pkg/v2/storage/etcd/update.go
@@ -1,0 +1,80 @@
+package etcd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+)
+
+// Update modifies an existing resource in etcd.
+//
+// Semantics: STRICT - Fails if resource doesn't exist (standard Kubernetes behavior)
+//
+// The implementation first checks if the resource exists via Get(), then performs Put.
+// This ensures strict Update semantics matching Kubernetes API.
+//
+// Returns:
+//   - nil on success
+//   - storage.ErrNotFound if resource doesn't exist
+//   - Other errors for etcd/marshaling failures
+func (r *EtcdRepository[T]) Update(ctx context.Context, obj T) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := r.keyFromObject(obj)
+
+	// Check if resource exists
+	resp, err := r.client.Get(ctx, key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to check if resource exists in etcd",
+			"type", r.resourceType,
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+		)
+		return fmt.Errorf("failed to check existence for %s: %w", r.resourceType, err)
+	}
+
+	if len(resp.Kvs) == 0 {
+		klog.V(4).InfoS("Resource not found in etcd, cannot update",
+			"type", r.resourceType,
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+			"key", key,
+		)
+		return errors.NewNotFound(r.gr, obj.GetName())
+	}
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(obj)
+	if err != nil {
+		klog.ErrorS(err, "Failed to marshal resource",
+			"type", r.resourceType,
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+		)
+		return fmt.Errorf("failed to marshal %s: %w", r.resourceType, err)
+	}
+
+	// Update in etcd
+	_, err = r.client.Put(ctx, key, string(jsonData))
+	if err != nil {
+		klog.ErrorS(err, "Failed to update resource in etcd",
+			"type", r.resourceType,
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+		)
+		return fmt.Errorf("failed to update %s in etcd: %w", r.resourceType, err)
+	}
+
+	klog.V(4).InfoS("Updated resource in etcd",
+		"type", r.resourceType,
+		"name", obj.GetName(),
+		"namespace", obj.GetNamespace(),
+		"key", key,
+	)
+
+	return nil
+}


### PR DESCRIPTION
Added:
- pkg/v2/storage/etcd: Complete etcd implementation of IRepository[T]
  - repository.go: Core struct with etcd client and key generation
  - create.go: Strict Create operation (fails if resource exists)
  - retrieve.go: Get and List operations with prefix queries
  - update.go: Strict Update operation (fails if resource doesn't exist)
  - delete.go: Delete operation with proper verification

Implementation Details:
- Uses clientv3.KV for etcd operations
- Thread-safe with sync.Mutex for operation consistency
- Key format: "group/version/kind/namespace/name" for namespaced resources
- Key format: "group/version/kind/name" for cluster-scoped resources
- Prefix queries for efficient listing operations
- Strict Kubernetes API semantics (Create fails if exists, Update fails if not exists)
- Proper error handling with NotFound and AlreadyExists errors
- Structured logging with klog at appropriate verbosity levels

Key Features:
- Unified repository handling both namespaced and cluster-scoped resources
- Protects against misuse (ignores namespace for cluster-scoped resources)
- JSON marshaling/unmarshaling for object storage
- ResourceVersion automatically stored as part of ObjectMeta
- All code builds successfully with no linter errors

This completes the v2 storage layer with three backends:
- inmemory: Map-based storage for dev/test
- postgres: SQL database for production
- etcd: Distributed KV store for Kubernetes-native deployments